### PR TITLE
Fix touch sensitivity for navigation items

### DIFF
--- a/lib/src/snake_item_tile.dart
+++ b/lib/src/snake_item_tile.dart
@@ -31,6 +31,7 @@ class SnakeItemTile extends StatelessWidget {
     return Expanded(
       child: GestureDetector(
         onTap: () => notifier.selectIndex(position),
+        behavior: HitTestBehavior.translucent,
         child: Center(
           child: LayoutBuilder(
             builder: (context, constraint) {


### PR DESCRIPTION
Currently, you can only activate a tab by touching the Text or Icon. It doesn't respect touches on the Tile itself. This fixes that issue.